### PR TITLE
Notification.find, Notification.find_all and Subscription.count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+.bundle

--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ The methods above return an hash:
 - `"scheduled"` is the estimated reach of the notification (i.e. the number of devices to which the notification will be sent, which can be different from the number of users, since a user may receive notifications on multiple devices)
 - `"uids"` (`deliver_to` only) are the user IDs that will be actually reached by the notification because they are subscribed to your notifications. For example if you send a notification to `['uid1', 'uid2', 'uid3']`, but only `'uid1'` is subscribed, you will get `['uid1']` in response. Note that if a user has unsubscribed after the last notification sent to him, he may still be reported for one time as subscribed (this is due to [the way](http://blog.pushpad.xyz/2016/05/the-push-api-and-its-wild-unsubscription-mechanism/) the W3C Push API works).
 
+The `id` and `scheduled_count` attribute are also stored on the notification object:
+
+```ruby
+
+notification.deliver_to user
+
+notification.id # => 1000
+notification.scheduled_count # => 5
+```
+
 ## Getting push notification data
 
 You can retrieve data for past notifications:

--- a/README.md
+++ b/README.md
@@ -111,13 +111,37 @@ notification.broadcast
 
 If no user with that id has subscribed to push notifications, that id is simply ignored.
 
-The methods above return an hash: 
+The methods above return an hash:
 
 - `"id"` is the id of the notification on Pushpad
 - `"scheduled"` is the estimated reach of the notification (i.e. the number of devices to which the notification will be sent, which can be different from the number of users, since a user may receive notifications on multiple devices)
 - `"uids"` (`deliver_to` only) are the user IDs that will be actually reached by the notification because they are subscribed to your notifications. For example if you send a notification to `['uid1', 'uid2', 'uid3']`, but only `'uid1'` is subscribed, you will get `['uid1']` in response. Note that if a user has unsubscribed after the last notification sent to him, he may still be reported for one time as subscribed (this is due to [the way](http://blog.pushpad.xyz/2016/05/the-push-api-and-its-wild-unsubscription-mechanism/) the W3C Push API works).
 
+## Getting push notification data
+
+You can retrieve data for past notifications:
+
+```ruby
+notification = Pushpad::Notification.find(42)
+
+# get basic attributes
+notification.id # => 42
+notification.title # => "Foo Bar",
+notification.body # => "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+notification.target_url # => "http://example.com",
+notification.ttl # => 604800,
+notification.require_interaction # => false,
+notification.icon_url # => "http://example.com/assets/icon.png",
+
+# `created_at` is a `Time` instance
+notification.created_at.utc.to_s # => "2016-07-06 10:09:14 UTC",
+
+# get statistics
+notification.scheduled_count # => 1
+notification.successfully_sent_count # => 4,
+notification.opened_count # => 2
+```
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/README.md
+++ b/README.md
@@ -152,6 +152,26 @@ notification.successfully_sent_count # => 4,
 notification.opened_count # => 2
 ```
 
+Or for mutliple notifications of a project at once:
+
+```ruby
+notifications = Pushpad::Notification.find_all(project_id: 5)
+
+# same attributes as for single notification in example above
+notifications[0].id # => 42
+notifications[0].title # => "Foo Bar",
+```
+
+If `Pushpad.project_id` is defined, the `project_id` option can be
+omitted.
+
+The REST API paginates the result set. You can pass a `page` parameter
+to get the full list in multiple requests.
+
+```ruby
+notifications = Pushpad::Notification.find_all(project_id: 5, page: 2)
+```
+
 ## Getting subscription count
 
 You can retrieve the number of subscriptions for a given project,

--- a/README.md
+++ b/README.md
@@ -152,6 +152,22 @@ notification.successfully_sent_count # => 4,
 notification.opened_count # => 2
 ```
 
+## Getting subscription count
+
+You can retrieve the number of subscriptions for a given project,
+optionally filtered by `tags` or `uids`:
+
+```ruby
+Pushpad::Subscription.count(project_id: 5) # => 100
+Pushpad::Subscription.count(project_id: 5, uids: ['user1']) # => 2
+Pushpad::Subscription.count(project_id: 5, tags: ['sports']) # => 10
+Pushpad::Subscription.count(project_id: 5, tags: 'sports && travel') # => 5
+Pushpad::Subscription.count(project_id: 5, uids: ['user1'], tags: 'sports && travel') # => 1
+```
+
+If `Pushpad.project_id` is defined, the `project_id` option can be
+omitted.
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/lib/pushpad.rb
+++ b/lib/pushpad.rb
@@ -1,7 +1,6 @@
-require 'net/http'
 require 'openssl'
-require 'json'
 
+require "pushpad/request"
 require "pushpad/notification"
 
 module Pushpad

--- a/lib/pushpad.rb
+++ b/lib/pushpad.rb
@@ -2,6 +2,7 @@ require 'openssl'
 
 require "pushpad/request"
 require "pushpad/notification"
+require "pushpad/subscription"
 
 module Pushpad
   @@auth_token = nil

--- a/lib/pushpad/notification.rb
+++ b/lib/pushpad/notification.rb
@@ -42,6 +42,23 @@ module Pushpad
       new(JSON.parse(response.body, symbolize_names: true))
     end
 
+    def self.find_all(options = {})
+      project_id = options[:project_id] || Pushpad.project_id
+      raise "You must set project_id" unless project_id
+
+      query_parameters = {}
+      query_parameters[:page] = options[:page] if options.key?(:page)
+
+      response = Request.get("https://pushpad.xyz/projects/#{project_id}/notifications",
+                             query_parameters: query_parameters)
+
+      unless response.code == "200"
+        raise FindError, "Response #{response.code} #{response.message}: #{response.body}"
+      end
+
+      JSON.parse(response.body, symbolize_names: true).map { |attributes| new(attributes) }
+    end
+
     def broadcast(options = {})
       deliver req_body(nil, options[:tags]), options
     end

--- a/lib/pushpad/notification.rb
+++ b/lib/pushpad/notification.rb
@@ -74,7 +74,10 @@ module Pushpad
         raise DeliveryError, "Response #{response.code} #{response.message}: #{response.body}"
       end
 
-      JSON.parse(response.body)
+      JSON.parse(response.body).tap do |attributes|
+        @id = attributes["id"]
+        @scheduled_count = attributes["scheduled"]
+      end
     end
 
     def req_body(uids = nil, tags = nil)

--- a/lib/pushpad/notification.rb
+++ b/lib/pushpad/notification.rb
@@ -1,0 +1,71 @@
+module Pushpad
+  class Notification
+    class DeliveryError < RuntimeError
+    end
+
+    attr_accessor :body, :title, :target_url, :icon_url, :ttl, :require_interaction
+
+    def initialize(options)
+      self.body = options[:body]
+      self.title = options[:title]
+      self.target_url = options[:target_url]
+      self.icon_url = options[:icon_url]
+      self.ttl = options[:ttl]
+      self.require_interaction = options[:require_interaction]
+    end
+
+    def broadcast(options = {})
+      deliver req_body(nil, options[:tags]), options
+    end
+
+    def deliver_to(users, options = {})
+      uids = if users.respond_to?(:ids)
+        users.ids
+      elsif users.respond_to?(:collect)
+        users.collect {|u| u.respond_to?(:id) ? u.id : u }
+      else
+        [users.respond_to?(:id) ? users.id : users]
+      end
+      deliver req_body(uids, options[:tags]), options
+    end
+
+    private
+
+    def deliver(req_body, options = {})
+      project_id = options[:project_id] || Pushpad.project_id
+      raise "You must set project_id" unless project_id
+      endpoint = "https://pushpad.xyz/projects/#{project_id}/notifications"
+      uri = URI.parse(endpoint)
+      https = Net::HTTP.new(uri.host, uri.port)
+      https.use_ssl = true
+      req = Net::HTTP::Post.new(uri.path, req_headers)
+      req.body = req_body
+      res = https.request(req)
+      raise DeliveryError, "Response #{res.code} #{res.message}: #{res.body}" unless res.code == '201'
+      JSON.parse(res.body)
+    end
+
+    def req_headers
+      raise "You must set Pushpad.auth_token" unless Pushpad.auth_token
+      {
+        'Authorization' => 'Token token="' + Pushpad.auth_token + '"',
+        'Content-Type' => 'application/json;charset=UTF-8',
+        'Accept' => 'application/json'
+      }
+    end
+
+    def req_body(uids = nil, tags = nil)
+      notification_params = { "body" => self.body }
+      notification_params["title"] = self.title if self.title
+      notification_params["target_url"] = self.target_url if self.target_url
+      notification_params["icon_url"] = self.icon_url if self.icon_url
+      notification_params["ttl"] = self.ttl if self.ttl
+      notification_params["require_interaction"] = self.require_interaction unless self.require_interaction.nil?
+
+      body = { "notification" => notification_params }
+      body["uids"] = uids if uids
+      body["tags"] = tags if tags
+      body.to_json
+    end
+  end
+end

--- a/lib/pushpad/request.rb
+++ b/lib/pushpad/request.rb
@@ -6,28 +6,29 @@ module Pushpad
     extend self
 
     def head(endpoint, options = {})
-      uri = URI.parse(endpoint)
-      request = Net::HTTP::Head.new(path_and_query(uri, options[:query_parameters]), headers)
-
-      https(uri, request)
+      perform(Net::HTTP::Head, endpoint, options)
     end
 
-    def get(endpoint)
-      uri = URI.parse(endpoint)
-      request = Net::HTTP::Get.new(uri.path, headers)
-
-      https(uri, request)
+    def get(endpoint, options = {})
+      perform(Net::HTTP::Get, endpoint, options)
     end
 
-    def post(endpoint, body)
-      uri = URI.parse(endpoint)
-      request = Net::HTTP::Post.new(uri.path, headers)
-      request.body = body
-
-      https(uri, request)
+    def post(endpoint, body, options = {})
+      perform(Net::HTTP::Post, endpoint, options) do |request|
+        request.body = body
+      end
     end
 
     private
+
+    def perform(method, endpoint, options)
+      uri = URI.parse(endpoint)
+      request = method.new(path_and_query(uri, options[:query_parameters]), headers)
+
+      yield request if block_given?
+
+      https(uri, request)
+    end
 
     def path_and_query(uri, query_parameters)
       [uri.path, query(query_parameters)].compact.join("?")

--- a/lib/pushpad/request.rb
+++ b/lib/pushpad/request.rb
@@ -1,0 +1,40 @@
+require "uri"
+require "net/http"
+
+module Pushpad
+  module Request
+    extend self
+
+    def get(endpoint)
+      uri = URI.parse(endpoint)
+      request = Net::HTTP::Get.new(uri.path, headers)
+
+      https(uri, request)
+    end
+
+    def post(endpoint, body)
+      uri = URI.parse(endpoint)
+      request = Net::HTTP::Post.new(uri.path, headers)
+      request.body = body
+
+      https(uri, request)
+    end
+
+    private
+
+    def https(uri, request)
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |https|
+        https.request(request)
+      end
+    end
+
+    def headers
+      raise "You must set Pushpad.auth_token" unless Pushpad.auth_token
+      {
+        "Authorization" => %(Token token="#{Pushpad.auth_token}"),
+        "Content-Type" => "application/json;charset=UTF-8",
+        "Accept" => "application/json"
+      }
+    end
+  end
+end

--- a/lib/pushpad/request.rb
+++ b/lib/pushpad/request.rb
@@ -5,6 +5,13 @@ module Pushpad
   module Request
     extend self
 
+    def head(endpoint, options = {})
+      uri = URI.parse(endpoint)
+      request = Net::HTTP::Head.new(path_and_query(uri, options[:query_parameters]), headers)
+
+      https(uri, request)
+    end
+
     def get(endpoint)
       uri = URI.parse(endpoint)
       request = Net::HTTP::Get.new(uri.path, headers)
@@ -21,6 +28,14 @@ module Pushpad
     end
 
     private
+
+    def path_and_query(uri, query_parameters)
+      [uri.path, query(query_parameters)].compact.join("?")
+    end
+
+    def query(parameters)
+      parameters && !parameters.empty? ? URI.encode_www_form(parameters) : nil
+    end
 
     def https(uri, request)
       Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |https|

--- a/lib/pushpad/subscription.rb
+++ b/lib/pushpad/subscription.rb
@@ -1,0 +1,52 @@
+module Pushpad
+  class Subscription
+    class CountError < RuntimeError
+    end
+
+    def self.count(options = {})
+      CountQuery.new(options).perform
+    end
+
+    class CountQuery
+      attr_reader :options
+
+      def initialize(options)
+        @options = options
+      end
+
+      def perform
+        project_id = options[:project_id] || Pushpad.project_id
+        raise "You must set project_id" unless project_id
+
+        endpoint = "https://pushpad.xyz/projects/#{project_id}/subscriptions"
+        response = Request.head(endpoint, query_parameters: query_parameters)
+
+        unless response.code == "200"
+          raise CountError, "Response #{response.code} #{response.message}: #{response.body}"
+        end
+
+        response["X-Total-Count"].to_i
+      end
+
+      private
+
+      def query_parameters
+        [uid_query_parameters, tag_query_parameters].flatten(1)
+      end
+
+      def uid_query_parameters
+        options.fetch(:uids, []).map { |uid| ["uids[]", uid] }
+      end
+
+      def tag_query_parameters
+        tags = options.fetch(:tags, [])
+
+        if tags.is_a?(String)
+          [["tags", tags]]
+        else
+          tags.map { |tag| ["tags[]", tag] }
+        end
+      end
+    end
+  end
+end

--- a/spec/pushpad/notification_spec.rb
+++ b/spec/pushpad/notification_spec.rb
@@ -6,10 +6,78 @@ module Pushpad
     let!(:project_id) { Pushpad.project_id = 123 }
     let(:notification) { Pushpad::Notification.new body: "Example message" }
 
+    def stub_notification_get(attributes)
+      stub_request(:get, "https://pushpad.xyz/notifications/#{attributes[:id]}").
+        to_return(status: 200, body: attributes.to_json)
+    end
+
+    def stub_failing_notification_get(notification_id)
+      stub_request(:get, "https://pushpad.xyz/notifications/#{notification_id}").
+        to_return(status: 404)
+    end
+
     def stub_notification_post(project_id, params)
       stub_request(:post, "https://pushpad.xyz/projects/#{project_id}/notifications").
         with(body: hash_including(params)).
         to_return(status: 201, body: "{}")
+    end
+
+    def stub_failing_notification_post(project_id)
+      stub_request(:post, "https://pushpad.xyz/projects/#{project_id}/notifications").
+        to_return(status: 403)
+    end
+
+    describe ".find" do
+      it "returns notification with attributes from json response" do
+        attributes = {
+          id: 5,
+          title: "Foo Bar",
+          body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+          target_url: "http://example.com",
+          created_at: "2016-07-06T10:09:14.835Z",
+          ttl: 604800,
+          require_interaction: false,
+          icon_url: "https://example.com/assets/icon.png",
+          scheduled_count: 2,
+          successfully_sent_count: 4,
+          opened_count: 1
+        }
+        stub_notification_get(attributes)
+
+        notification = Notification.find(5)
+
+        attributes.delete(:created_at)
+        expect(notification).to have_attributes(attributes)
+        expect(notification.created_at.utc.to_s).to eq(Time.utc(2016, 7, 6, 10, 9, 14.835).to_s)
+      end
+
+      it "fails with FindError if response status code is not 200" do
+        stub_failing_notification_get(5)
+
+        expect {
+          Notification.find(5)
+        }.to raise_error(Notification::FindError)
+      end
+
+      it "returns notification that fails with ReadOnlyError when calling deliver_to" do
+        stub_notification_get(id: 5)
+
+        notification = Notification.find(5)
+
+        expect {
+          notification.deliver_to(100)
+        }.to raise_error(Notification::ReadOnlyError)
+      end
+
+      it "returns notification that fails with ReadOnlyError when calling broadcast" do
+        stub_notification_get(id: 5)
+
+        notification = Notification.find(5)
+
+        expect {
+          notification.broadcast
+        }.to raise_error(Notification::ReadOnlyError)
+      end
     end
 
     describe "#deliver_to" do
@@ -67,6 +135,14 @@ module Pushpad
           expect(req).to have_been_made.once
         end
       end
+
+      it "fails with DeliveryError if response status code is not 201" do
+        stub_failing_notification_post(project_id)
+
+        expect {
+          notification.deliver_to(100)
+        }.to raise_error(Notification::DeliveryError)
+      end
     end
 
     describe "#broadcast" do
@@ -115,6 +191,14 @@ module Pushpad
           notification.broadcast tags: ["tag1", "tag2"]
           expect(req).to have_been_made.once
         end
+      end
+
+      it "fails with DeliveryError if response status code is not 201" do
+        stub_failing_notification_post(project_id)
+
+        expect {
+          notification.broadcast
+        }.to raise_error(Notification::DeliveryError)
       end
     end
   end

--- a/spec/pushpad/notification_spec.rb
+++ b/spec/pushpad/notification_spec.rb
@@ -1,0 +1,121 @@
+require "spec_helper"
+
+module Pushpad
+  describe Notification do
+    let!(:auth_token) { Pushpad.auth_token = "abc123" }
+    let!(:project_id) { Pushpad.project_id = 123 }
+    let(:notification) { Pushpad::Notification.new body: "Example message" }
+
+    def stub_notification_post(project_id, params)
+      stub_request(:post, "https://pushpad.xyz/projects/#{project_id}/notifications").
+        with(body: hash_including(params)).
+        to_return(status: 201, body: "{}")
+    end
+
+    describe "#deliver_to" do
+      shared_examples "notification params" do
+        it "includes the params in the request" do
+          req = stub_notification_post project_id, notification: notification_params
+          notification.deliver_to [123, 456]
+          expect(req).to have_been_made.once
+        end
+      end
+
+      context "a notification with just the required params" do
+        let(:notification_params) do
+          { body: "Example message" }
+        end
+        let(:notification) { Pushpad::Notification.new body: notification_params[:body] }
+        include_examples "notification params"
+      end
+
+      context "a notification with all the optional params" do
+        let(:notification_params) do
+          {
+            body: "Example message",
+            title: "Website Name",
+            target_url: "http://example.com",
+            icon_url: "http://example.com/assets/icon.png",
+            ttl: 604800,
+            require_interaction: true
+          }
+        end
+        let(:notification) { Pushpad::Notification.new notification_params }
+        include_examples "notification params"
+      end
+
+      context "with a scalar as a param" do
+        it "reaches only that uid" do
+          req = stub_notification_post project_id, uids: [100]
+          notification.deliver_to(100)
+          expect(req).to have_been_made.once
+        end
+      end
+
+      context "with an array as a param" do
+        it "reaches only those uids" do
+          req = stub_notification_post project_id, uids: [123, 456]
+          notification.deliver_to([123, 456])
+          expect(req).to have_been_made.once
+        end
+      end
+
+      context "with uids and tags" do
+        it "filters audience by uids and tags" do
+          req = stub_notification_post project_id, uids: [123, 456], tags: ["tag1"]
+          notification.deliver_to([123, 456], tags: ["tag1"])
+          expect(req).to have_been_made.once
+        end
+      end
+    end
+
+    describe "#broadcast" do
+      shared_examples "notification params" do
+        it "includes the params in the request" do
+          req = stub_notification_post project_id, notification: notification_params
+          notification.broadcast
+          expect(req).to have_been_made.once
+        end
+      end
+
+      context "a notification with just the required params" do
+        let(:notification_params) do
+          { body: "Example message" }
+        end
+        let(:notification) { Pushpad::Notification.new body: notification_params[:body] }
+        include_examples "notification params"
+      end
+
+      context "a notification with all the optional params" do
+        let(:notification_params) do
+          {
+            body: "Example message",
+            title: "Website Name",
+            target_url: "http://example.com",
+            icon_url: "http://example.com/assets/icon.png",
+            ttl: 604800,
+            require_interaction: true
+          }
+        end
+        let(:notification) { Pushpad::Notification.new notification_params }
+        include_examples "notification params"
+      end
+
+      context "without params" do
+        it "reaches everyone" do
+          req = stub_notification_post project_id, {}
+          notification.broadcast
+          expect(req).to have_been_made.once
+        end
+      end
+
+      context "with tags" do
+        it "filters audience by tags" do
+          req = stub_notification_post project_id, tags: ["tag1", "tag2"]
+          notification.broadcast tags: ["tag1", "tag2"]
+          expect(req).to have_been_made.once
+        end
+      end
+    end
+  end
+end

--- a/spec/pushpad/notification_spec.rb
+++ b/spec/pushpad/notification_spec.rb
@@ -27,7 +27,7 @@ module Pushpad
         to_return(status: 403)
     end
 
-    def stub_notification_post(project_id, params, response_body = "{}")
+    def stub_notification_post(project_id, params = {}, response_body = "{}")
       stub_request(:post, "https://pushpad.xyz/projects/#{project_id}/notifications").
         with(body: hash_including(params)).
         to_return(status: 201, body: response_body)
@@ -36,6 +36,16 @@ module Pushpad
     def stub_failing_notification_post(project_id)
       stub_request(:post, "https://pushpad.xyz/projects/#{project_id}/notifications").
         to_return(status: 403)
+    end
+
+    describe ".new" do
+      it "allows delivering notifications even if an id attribute is supplied" do
+        stub_notification_post(project_id)
+
+        expect {
+          Notification.new(id: "ignored").broadcast
+        }.not_to raise_error
+      end
     end
 
     describe ".find" do
@@ -70,24 +80,24 @@ module Pushpad
         }.to raise_error(Notification::FindError)
       end
 
-      it "returns notification that fails with ReadOnlyError when calling deliver_to" do
+      it "returns notification that fails with ReadonlyError when calling deliver_to" do
         stub_notification_get(id: 5)
 
         notification = Notification.find(5)
 
         expect {
           notification.deliver_to(100)
-        }.to raise_error(Notification::ReadOnlyError)
+        }.to raise_error(Notification::ReadonlyError)
       end
 
-      it "returns notification that fails with ReadOnlyError when calling broadcast" do
+      it "returns notification that fails with ReadonlyError when calling broadcast" do
         stub_notification_get(id: 5)
 
         notification = Notification.find(5)
 
         expect {
           notification.broadcast
-        }.to raise_error(Notification::ReadOnlyError)
+        }.to raise_error(Notification::ReadonlyError)
       end
     end
 
@@ -150,24 +160,24 @@ module Pushpad
         }.to raise_error(Notification::FindError)
       end
 
-      it "returns notifications that fail with ReadOnlyError when calling deliver_to" do
+      it "returns notifications that fail with ReadonlyError when calling deliver_to" do
         stub_notifications_get(project_id: 10, list: [{ id: 5 }])
 
         notifications = Notification.find_all(project_id: 10)
 
         expect {
           notifications[0].deliver_to(100)
-        }.to raise_error(Notification::ReadOnlyError)
+        }.to raise_error(Notification::ReadonlyError)
       end
 
-      it "returns notifications that fail with ReadOnlyError when calling broadcast" do
+      it "returns notifications that fail with ReadonlyError when calling broadcast" do
         stub_notifications_get(project_id: 10, list: [{ id: 5 }])
 
         notifications = Notification.find_all(project_id: 10)
 
         expect {
           notifications[0].broadcast
-        }.to raise_error(Notification::ReadOnlyError)
+        }.to raise_error(Notification::ReadonlyError)
       end
     end
 

--- a/spec/pushpad/request_spec.rb
+++ b/spec/pushpad/request_spec.rb
@@ -33,6 +33,15 @@ module Pushpad
         expect(a_request(:get, "https://pushpad.xyz/example").
                with(headers: { "Authorization" => 'Token token="abc123"' })).to have_been_made
       end
+
+      it "supports passing query parameters" do
+        stub_request(:any, /pushpad.xyz/)
+
+        Pushpad.auth_token = "abc123"
+        Request.get("https://pushpad.xyz/example", query_parameters: [["some", "value"]])
+
+        expect(a_request(:get, "https://pushpad.xyz/example?some=value")).to have_been_made
+      end
     end
 
     describe ".post" do
@@ -54,6 +63,15 @@ module Pushpad
 
         expect(a_request(:post, "https://pushpad.xyz/example").
                with(body: '{"some": "value"}')).to have_been_made
+      end
+
+      it "supports passing query parameters" do
+        stub_request(:any, /pushpad.xyz/)
+
+        Pushpad.auth_token = "abc123"
+        Request.post("https://pushpad.xyz/example", "{}", query_parameters: [["some", "value"]])
+
+        expect(a_request(:post, "https://pushpad.xyz/example?some=value")).to have_been_made
       end
     end
   end

--- a/spec/pushpad/request_spec.rb
+++ b/spec/pushpad/request_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+module Pushpad
+  describe Request do
+    describe ".get" do
+      it "passes auth_token in authorization header" do
+        stub_request(:any, /pushpad.xyz/)
+
+        Pushpad.auth_token = "abc123"
+        Request.get("https://pushpad.xyz/example")
+
+        expect(a_request(:get, "https://pushpad.xyz/example").
+               with(headers: { "Authorization" => 'Token token="abc123"' })).to have_been_made
+      end
+    end
+
+    describe ".post" do
+      it "passes auth_token in authorization header" do
+        stub_request(:any, /pushpad.xyz/)
+
+        Pushpad.auth_token = "abc123"
+        Request.post("https://pushpad.xyz/example", '{"some": "value"}')
+
+        expect(a_request(:post, "https://pushpad.xyz/example").
+               with(headers: { "Authorization" => 'Token token="abc123"' })).to have_been_made
+      end
+
+      it "passes request body" do
+        stub_request(:any, /pushpad.xyz/)
+
+        Pushpad.auth_token = "abc123"
+        Request.post("https://pushpad.xyz/example", '{"some": "value"}')
+
+        expect(a_request(:post, "https://pushpad.xyz/example").
+               with(body: '{"some": "value"}')).to have_been_made
+      end
+    end
+  end
+end

--- a/spec/pushpad/request_spec.rb
+++ b/spec/pushpad/request_spec.rb
@@ -2,6 +2,27 @@ require "spec_helper"
 
 module Pushpad
   describe Request do
+    describe ".head" do
+      it "passes auth_token in authorization header" do
+        stub_request(:any, /pushpad.xyz/)
+
+        Pushpad.auth_token = "abc123"
+        Request.head("https://pushpad.xyz/example")
+
+        expect(a_request(:head, "https://pushpad.xyz/example").
+               with(headers: { "Authorization" => 'Token token="abc123"' })).to have_been_made
+      end
+
+      it "supports passing query parameters" do
+        stub_request(:any, /pushpad.xyz/)
+
+        Pushpad.auth_token = "abc123"
+        Request.head("https://pushpad.xyz/example", query_parameters: [["some", "value"]])
+
+        expect(a_request(:head, "https://pushpad.xyz/example?some=value")).to have_been_made
+      end
+    end
+
     describe ".get" do
       it "passes auth_token in authorization header" do
         stub_request(:any, /pushpad.xyz/)

--- a/spec/pushpad/subscription_spec.rb
+++ b/spec/pushpad/subscription_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+
+module Pushpad
+  describe Subscription do
+    def stub_subscriptions_head(options)
+      stub_request(:head, "https://pushpad.xyz/projects/#{options[:project_id]}/subscriptions").
+        with(query: hash_including(options.fetch(:query, {}))).
+        to_return(status: 200,
+                  headers: { "X-Total-Count" => options.fetch(:total_count, 10) })
+    end
+
+    def stub_failing_subscriptions_head(options)
+      stub_request(:head, "https://pushpad.xyz/projects/#{options[:project_id]}/subscriptions").
+        to_return(status: 503)
+    end
+
+    describe ".count" do
+      it "returns value from X-Total-Count header" do
+        stub_subscriptions_head(project_id: 5, total_count: 100)
+
+        result = Subscription.count(project_id: 5)
+
+        expect(result).to eq(100)
+      end
+
+      it "falls back to global project_id" do
+        request = stub_subscriptions_head(project_id: 5, total_count: 100)
+
+        Pushpad.project_id = 5
+        Subscription.count
+
+        expect(request).to have_been_made.once
+      end
+
+      it "fails with helpful error message when project_id is missing" do
+        Pushpad.project_id = nil
+
+        expect {
+          Subscription.count
+        }.to raise_error(/must set project_id/)
+      end
+
+      it "allows passing uids" do
+        request = stub_subscriptions_head(project_id: 5, query: { uids:  ["uid0", "uid1"] })
+
+        Subscription.count(project_id: 5, uids: ["uid0", "uid1"])
+
+        expect(request).to have_been_made.once
+      end
+
+      it "allows passing tags" do
+        request = stub_subscriptions_head(project_id: 5, query: { tags:  ["sports", "travel"] })
+
+        Subscription.count(project_id: 5, tags: ["sports", "travel"])
+
+        expect(request).to have_been_made.once
+      end
+
+      it "allows passing tags as boolean expression" do
+        request = stub_subscriptions_head(project_id: 5, query: { tags: "sports || travel" })
+
+        Subscription.count(project_id: 5, tags: "sports || travel")
+
+        expect(request).to have_been_made.once
+      end
+
+      it "allows passing tags and uids" do
+        request = stub_subscriptions_head(project_id: 5,
+                                          query: { tags:  ["sports", "travel"], uids: ["uid0"] })
+
+        Subscription.count(project_id: 5, tags: ["sports", "travel"], uids: ["uid0"])
+
+        expect(request).to have_been_made.once
+      end
+
+      it "fails with CountError if response status code is not 200" do
+        stub_failing_subscriptions_head(project_id: 5)
+
+        expect {
+          Subscription.count(project_id: 5)
+        }.to raise_error(Subscription::CountError)
+      end
+    end
+  end
+end

--- a/spec/pushpad_spec.rb
+++ b/spec/pushpad_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe Pushpad do
-  let!(:auth_token) { Pushpad.auth_token = 'abc123' }
-  let!(:project_id) { Pushpad.project_id = 123 }
-  let(:notification) { Pushpad::Notification.new body: "Example message" }
-
   describe "#auth_token=" do
     it "sets the Pushpad auth token globally" do
       Pushpad.auth_token = 'abc123'
@@ -23,120 +19,6 @@ describe Pushpad do
     it "produces the hex-encoded HMAC-SHA1 signature for the data passed as argument" do
       signature = Pushpad.signature_for('myuid1')
       expect(signature).to eq '27fbe136f5a4aa0b6be74c0e18fa8ce81ad91b60'
-    end
-  end
-
-  def stub_notification_post project_id, params
-    stub_request(:post, "https://pushpad.xyz/projects/#{project_id}/notifications").
-      with(body: hash_including(params)).
-      to_return(status: 201, body: '{}')
-  end
-
-  describe "#deliver_to" do
-    
-    shared_examples 'notification params' do
-      it "includes the params in the request" do
-        req = stub_notification_post project_id, notification: notification_params
-        notification.deliver_to [123, 456]
-        expect(req).to have_been_made.once
-      end
-    end
-
-    context "a notification with just the required params" do
-      let(:notification_params) do 
-        { body: "Example message" }
-      end
-      let(:notification) { Pushpad::Notification.new body: notification_params[:body] }
-      include_examples 'notification params'
-    end
-
-    context "a notification with all the optional params" do
-      let(:notification_params) do 
-        {
-          body: "Example message",
-          title: "Website Name",
-          target_url: "http://example.com",
-          icon_url: "http://example.com/assets/icon.png",
-          ttl: 604800,
-          require_interaction: true
-        }
-      end
-      let(:notification) { Pushpad::Notification.new notification_params } 
-      include_examples 'notification params'
-    end
-
-    context "with a scalar as a param" do
-      it "reaches only that uid" do
-        req = stub_notification_post project_id, uids: [100]
-        notification.deliver_to(100)
-        expect(req).to have_been_made.once
-      end
-    end
-
-    context "with an array as a param" do
-      it "reaches only those uids" do
-        req = stub_notification_post project_id, uids: [123, 456]
-        notification.deliver_to([123, 456])
-        expect(req).to have_been_made.once
-      end
-    end
-
-    context "with uids and tags" do
-      it "filters audience by uids and tags" do
-        req = stub_notification_post project_id, uids: [123, 456], tags: ['tag1']
-        notification.deliver_to([123, 456], tags: ['tag1'])
-        expect(req).to have_been_made.once
-      end
-    end
-  end
-
-  describe "#broadcast" do
-
-    shared_examples 'notification params' do
-      it "includes the params in the request" do
-        req = stub_notification_post project_id, notification: notification_params
-        notification.broadcast
-        expect(req).to have_been_made.once
-      end
-    end
-
-    context "a notification with just the required params" do
-      let(:notification_params) do 
-        { body: "Example message" }
-      end
-      let(:notification) { Pushpad::Notification.new body: notification_params[:body] }
-      include_examples 'notification params'
-    end
-
-    context "a notification with all the optional params" do
-      let(:notification_params) do 
-        {
-          body: "Example message",
-          title: "Website Name",
-          target_url: "http://example.com",
-          icon_url: "http://example.com/assets/icon.png",
-          ttl: 604800,
-          require_interaction: true
-        }
-      end
-      let(:notification) { Pushpad::Notification.new notification_params } 
-      include_examples 'notification params'
-    end
-
-    context "without params" do
-      it "reaches everyone" do
-        req = stub_notification_post project_id, {}
-        notification.broadcast
-        expect(req).to have_been_made.once
-      end
-    end
-
-    context "with tags" do
-      it "filters audience by tags" do
-        req = stub_notification_post project_id, tags: ['tag1', 'tag2']
-        notification.broadcast tags: ['tag1', 'tag2']
-        expect(req).to have_been_made.once
-      end
     end
   end
 end


### PR DESCRIPTION
fixes #3, #4 

So here is my first stab at the new features. I've put them in a single PR for now since the changes sort of build on one another, but I'm happy to split things up if you prefer. The first two commits move the notification code from `pushpad{,_spec}.rb` to `pushpad/notification{,_spec}.rb`. So you might want to look at the individual commits to get more meaningful diffs.

I've moved some of the request handling logic from the `Notification` class into a new `Pushpad::Request` module so it can be reused by `Subscription` and other future classes. 

I've tested the new features on the console. But I'd say, let me build my app against my fork for now to find further errors that might have gone unnoticed so far.

Looking forward to your feedback.

Tim